### PR TITLE
add wlr_glew_texture_get_attribs

### DIFF
--- a/include/wlr/render/glew.h
+++ b/include/wlr/render/glew.h
@@ -10,4 +10,16 @@ struct wlr_renderer *wlr_glew_renderer_create(struct wlr_egl *egl);
 
 struct wlr_egl *wlr_glew_renderer_get_egl(struct wlr_renderer *renderer);
 
+struct wlr_glew_texture_attribs {
+  uint32_t target;
+  uint32_t tex;
+
+  bool has_alpha;
+};
+
+bool wlr_texture_is_glew(struct wlr_texture *texture);
+
+void wlr_glew_texture_get_attribs(
+    struct wlr_texture *texture, struct wlr_glew_texture_attribs *attribs);
+
 #endif  //  WLR_RENDER_GLEW_H

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project(
   'wlr-glew-renderer', 'c',
-  version: '0.15.0',
+  version: '0.15.1.1',
   license: 'MIT',
   meson_version: '>=0.58.1',
   default_options: [
@@ -9,6 +9,8 @@ project(
     'werror=true',
   ],
 )
+
+so_version = '1.0'
 
 little_endian = host_machine.endian() == 'little'
 big_endian = host_machine.endian() == 'big'

--- a/src/meson.build
+++ b/src/meson.build
@@ -13,7 +13,7 @@ dependencies = [
 lib_wlr_glew_renderer = library(
   meson.project_name(), sources,
   dependencies: dependencies,
-  version: meson.project_version(),
+  version: so_version,
   include_directories: inc,
   install: true,
 )

--- a/src/texture.c
+++ b/src/texture.c
@@ -19,7 +19,7 @@
 
 static const struct wlr_texture_impl texture_impl;
 
-static bool
+WL_EXPORT bool
 wlr_texture_is_glew(struct wlr_texture *wlr_texture)
 {
   return wlr_texture->impl == &texture_impl;
@@ -377,4 +377,15 @@ glew_texture_from_buffer(
   } else {
     return NULL;
   }
+}
+
+WL_EXPORT void
+wlr_glew_texture_get_attribs(
+    struct wlr_texture *wlr_texture, struct wlr_glew_texture_attribs *attribs)
+{
+  struct wlr_glew_texture *texture = glew_get_texture(wlr_texture);
+  memset(attribs, 0, sizeof(*attribs));
+  attribs->target = texture->target;
+  attribs->tex = texture->tex;
+  attribs->has_alpha = texture->has_alpha;
 }


### PR DESCRIPTION
## Context

To get texture data from wlr_texture, we need texture_get_attribs func for glew renderer.

## Summary

- [x] implement wlr_glew_texture_get_atrribs

