### PR TITLE
stop compiling wlrooot examples

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -85,6 +85,9 @@ wlroots_proj = subproject(
   'wlroots',
   required: true,
   version: '0.15.1',
+  default_options: [
+    'examples=false',
+  ],
 )
 wlroots = wlroots_proj.get_variable('wlroots')
 


### PR DESCRIPTION
## Context

Compiling wlroots fails in arch linux, stop compiling examples will fix this.

## Summary

Stop compiling wlroots examples

## How to check behavior

compile this in arch linux